### PR TITLE
Update breakdown_line_item.rb

### DIFF
--- a/lib/taxjar/breakdown_line_item.rb
+++ b/lib/taxjar/breakdown_line_item.rb
@@ -4,7 +4,7 @@ module Taxjar
   class BreakdownLineItem < Taxjar::Base
     extend ModelAttribute
       
-    attribute :id,                              :integer
+    attribute :id,                              :string
     attribute :taxable_amount,                  :float
     attribute :tax_collectable,                 :float
     attribute :combined_tax_rate,               :float


### PR DESCRIPTION
Change type of `:id` to `:string`, to match the API reference. See: #22